### PR TITLE
Potential fix for code scanning alert no. 2: Reflected server-side cross-site scripting

### DIFF
--- a/nginx/oboi-wrapper.py
+++ b/nginx/oboi-wrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from flask import Flask, request, Response, send_file
-import os, subprocess, datetime, mimetypes, urllib.parse
+import os, subprocess, datetime, mimetypes, urllib.parse, html
 
 env = os.environ.copy()
 #env["OBOI_DLP_APIKEY"] = "YOUR_API_KEY_GOES_HERE"
@@ -41,16 +41,16 @@ def serve_and_filter(path):
             # No index file → generate HTML directory listing
             try:
                 files = sorted(os.listdir(full_path))
-                listing_html = f"<html><head><title>Index of /{path}</title></head><body>"
-                listing_html += f"<h1>Index of /{path}</h1><ul>"
+                listing_html = f"<html><head><title>Index of /{html.escape(path)}</title></head><body>"
+                listing_html += f"<h1>Index of /{html.escape(path)}</h1><ul>"
                 # Parent directory link if not root
                 if path:
                     parent = os.path.dirname(path.rstrip("/"))
-                    listing_html += f'<li><a href="/{parent}">..</a></li>'
+                    listing_html += f'<li><a href="/{html.escape(parent)}">..</a></li>'
                 for f in files:
                     f_path = os.path.join(path, f)
                     f_url = urllib.parse.quote(f_path)
-                    listing_html += f'<li><a href="/{f_url}">{f}</a></li>'
+                    listing_html += f'<li><a href="/{f_url}">{html.escape(f)}</a></li>'
                 listing_html += "</ul></body></html>"
                 return Response(listing_html, status=200, mimetype="text/html")
             except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/forshaws/homebrew-oboi-dlp/security/code-scanning/2](https://github.com/forshaws/homebrew-oboi-dlp/security/code-scanning/2)

To fix the reflected XSS, all instances in which the user-provided `path` or derived variables (e.g., `f`, `parent`, `f_path`) are incorporated into the HTML must be escaped. The best and simplest method is to use Python's `html.escape()` function whenever user input is inserted into HTML markup. This includes the document title, heading, and the listing links. In detail:

- Import the standard library `html` module at the top of the file.
- In the directory listing HTML generation block (lines 44-54), apply `html.escape()` to every interpolated user-provided value:
  - `path` in `<title>` and `<h1>`
  - `parent` in the parent directory link
  - `f` in the filename part (link label)
  - (Optionally, `f_url` in href, though URLs should be safely quoted already via `urllib.parse.quote`, so escaping isn't required there.)
- Make these replacements inside the `serve_and_filter` function.

No other modifications are needed outside the directory listing region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
