### PR TITLE
Potential fix for code scanning alert no. 2: Reflected server-side cross-site scripting

### DIFF
--- a/nginx/oboi-wrapper.py
+++ b/nginx/oboi-wrapper.py
@@ -50,7 +50,7 @@ def serve_and_filter(path):
                 for f in files:
                     f_path = os.path.join(path, f)
                     f_url = urllib.parse.quote(f_path)
-                    listing_html += f'<li><a href="/{f_url}">{html.escape(f)}</a></li>'
+                    listing_html += f'<li><a href="/{html.escape(f_url)}">{html.escape(f)}</a></li>'
                 listing_html += "</ul></body></html>"
                 return Response(listing_html, status=200, mimetype="text/html")
             except Exception as e:


### PR DESCRIPTION
Potential fix for [https://github.com/forshaws/homebrew-oboi-dlp/security/code-scanning/2](https://github.com/forshaws/homebrew-oboi-dlp/security/code-scanning/2)

To fix this issue, ensure that any user- (or filesystem-) controlled strings interpolated into HTML are properly escaped for safe rendering in the browser. For link `href` attributes, both URL encoding and then HTML escaping should be applied: URL-encode to ensure valid URLs, then HTML-escape to prevent injection inside the attribute value.  
**Edit**: In `nginx/oboi-wrapper.py`, in the directory listing block (lines 53), change the interpolation for `href` so that after computing `f_url`, you escape it with `html.escape()` inside the anchor tag. This guarantees that even if `f_url` contains characters that could close the attribute or inject code, they're safely escaped.  
No additional imports are needed: `html.escape` is already imported.  
Only lines in the directory listing block (the HTML-building section) need to be changed; other usage of `html.escape` is already correct.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
