### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/nginx/oboi-wrapper.py
+++ b/nginx/oboi-wrapper.py
@@ -86,7 +86,7 @@ def serve_and_filter(path):
 
         except Exception as e:
             print(f"[ERROR] Failed processing {full_path}: {e}")
-            return Response(f"Error reading file: {e}\n", status=500, mimetype="text/plain")
+            return Response("Error reading file\n", status=500, mimetype="text/plain")
 
     # File does not exist
     print(f"[WARN] File not found: {full_path}")


### PR DESCRIPTION
Potential fix for [https://github.com/forshaws/homebrew-oboi-dlp/security/code-scanning/1](https://github.com/forshaws/homebrew-oboi-dlp/security/code-scanning/1)

To resolve this issue, we should avoid returning the exception message (`{e}`) in the HTTP response sent to users. Instead, we should return a generic error message (“An internal error has occurred”, or similar), as recommended.

For diagnostics, we should keep logging the error message on the server (as is already done with `print(f"[ERROR] Failed processing {full_path}: {e}")`), so developers can investigate using server logs. The code change is isolated to line 89 in function `serve_and_filter`. We replace the error response message with a fixed, generic string, such as `"Error reading file\n"`, without interpolation of `e`.

No changes are necessary to imports or method definitions—the existing error logging is adequate.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
